### PR TITLE
Fix/workarounds

### DIFF
--- a/assets/js/content-checker.js
+++ b/assets/js/content-checker.js
@@ -10,7 +10,9 @@
 		var insecure = 0;
 		var $images;
 		var insecureImageURLs = [];
-		if ( $('#wp-content-wrap').hasClass('tinymce-active') ) {
+		var $visualEditorWrap = $( document.getElementById( 'wp-content-wrap' ) );
+		if ( $visualEditorWrap.hasClass('tmce-active') ||
+				$visualEditorWrap.hasClass('tinymce-active') ) {
 			$images = $('#content_ifr').contents().find('img');
 		} else {
 			$images = $('<div>').append( $.parseHTML( $('#content').val() ) ).find('img');


### PR DESCRIPTION
I suspect the instances of insecure images getting past the filter are due to IE users. String.prototype.startsWith has no IE support, so any IE user would effectively bypass the filter. I switched it to comparing with substr().

I couldn't reproduce Miranda's report that she could delete an image from the content and it would take 2-3 clicks before it would accept that the image was removed. I don't see any reason why that would happen in the code, so I'm guessing maybe the first couple "clicks" weren't legit clicks on the button that registered its click event.

I also took a few minutes to make it output a list of the violating image URLs so if we continue to have problems it will be easier to see exactly what URLs are causing the issue.