### PR TITLE
Make https check ignore the page break image WP inserts

### DIFF
--- a/assets/js/content-checker.js
+++ b/assets/js/content-checker.js
@@ -18,7 +18,8 @@
 			$images = $('<div>').append( $.parseHTML( $('#content').val() ) ).find('img');
 		}
 		$images.each( function( index, el ) {
-			if ( el.src && 'https://' !== el.src.substr( 0, 8 ) ) {
+			if ( el.src && 'https://' !== el.src.substr( 0, 8 ) &&
+					'data:image' !== el.src.substr( 0, 10 ) ) {
 				insecure += 1;
 				insecureImageURLs.push( el.src );
 			}


### PR DESCRIPTION
Small update. This will make the script stop identifying the page break image that WordPress inserts into the Visual Editor when the `<!--nextpage-->` shortcode is used. As long as the site uses HTTPS then images inserted as data URIs will be HTTPS.