### PR TITLE
Fix E2E Tests and Upgrade Cypress to version 13

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -44,7 +44,7 @@ jobs:
       matrix:
         core:
           - {name: 'WP latest', version: 'latest'}
-          - {name: 'WP minimum', version: 'WordPress/WordPress#5.7'}
+          - {name: 'WP minimum', version: 'WordPress/WordPress#5.8'}
           - {name: 'WP trunk', version: 'WordPress/WordPress#master'}
     steps:
     - name: Checkout

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -71,7 +71,6 @@ jobs:
     - run: npm ci
       if: ${{ steps.cache-node.outputs.cache-hit != 'true' }}
     - run: npm run build
-      if: ${{ steps.cache-build.outputs.cache-hit != 'true' }}
     - name: Set the core version
       run: ./tests/bin/set-core-version.js ${{ matrix.core.version }}
     - name: Set up WP environment

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -78,3 +78,13 @@ jobs:
       run: npm run env:start
     - name: Test
       run: npm run cypress:run
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v3
+      if: failure()
+      with:
+        name: cypress-artifact-insecure-content-warning
+        retention-days: 2
+        path: |
+          ${{ github.workspace }}/tests/cypress/screenshots/
+          ${{ github.workspace }}/tests/cypress/videos/
+          ${{ github.workspace }}/tests/cypress/logs/

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Compatible with both the block and classic editors.
 ## Requirements
 
 * PHP 7.4+.
-* WordPress 5.7+.
+* WordPress 5.8+.
 * A secure / SSL (HTTPS) website, front and back end.
 
 ## Installation

--- a/insecure-content-warning.php
+++ b/insecure-content-warning.php
@@ -4,7 +4,7 @@
  * Plugin URI:        https://wordpress.org/plugins/insecure-content-warning/
  * Description:       Prevent editors from adding insecure content in the editor.
  * Version:           1.1.0
- * Requires at least: 5.7
+ * Requires at least: 5.8
  * Requires PHP:      7.4
  * Author:            10up
  * Author URI:        https://10up.com/

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,11 +15,11 @@
         "underscore": "^1.12.1"
       },
       "devDependencies": {
-        "@10up/cypress-wp-utils": "github:10up/cypress-wp-utils#build",
-        "@wordpress/env": "^5.8.0",
+        "@10up/cypress-wp-utils": "^0.2.0",
+        "@wordpress/env": "^8.7.0",
         "@wordpress/eslint-plugin": "^14.11.0",
         "@wordpress/scripts": "^26.9.0",
-        "cypress": "^11.2.0",
+        "cypress": "^13.2.0",
         "eslint": "^8.46.0",
         "eslint-plugin-prettier": "^5.0.0",
         "husky": "^3.1.0",
@@ -30,10 +30,10 @@
       }
     },
     "node_modules/@10up/cypress-wp-utils": {
-      "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/10up/cypress-wp-utils.git#dfd99433b9d63a757810e1e4e285796d63fdc140",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@10up/cypress-wp-utils/-/cypress-wp-utils-0.2.0.tgz",
+      "integrity": "sha512-5gzamtHIFojT+wx0OzSAEeVY6FVrlcVPHVFH23uExkaqQhNsJvrnpdtqtT98wAYkXg56c1qDN7Ju7ZRTaNzP5g==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=12.0"
       }
@@ -1947,9 +1947,9 @@
       }
     },
     "node_modules/@cypress/request": {
-      "version": "2.88.12",
-      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.12.tgz",
-      "integrity": "sha512-tOn+0mDZxASFM+cuAP9szGUGPI1HwWVSvdzm7V4cCsPdFTx6qMj29CwaQmRAMIEhORIUBFBsYROYJcveK4uOjA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.1.tgz",
+      "integrity": "sha512-TWivJlJi8ZDx2wGOw1dbLuHJKUYX7bWySw377nlnGOW3hP9/MUKIsEdXT/YngWxVdgNCHRBmFlBipE+5/2ZZlQ==",
       "dev": true,
       "dependencies": {
         "aws-sign2": "~0.7.0",
@@ -1965,7 +1965,7 @@
         "json-stringify-safe": "~5.0.1",
         "mime-types": "~2.1.19",
         "performance-now": "^2.1.0",
-        "qs": "~6.10.3",
+        "qs": "6.10.4",
         "safe-buffer": "^5.1.2",
         "tough-cookie": "^4.1.3",
         "tunnel-agent": "^0.6.0",
@@ -4597,9 +4597,9 @@
       }
     },
     "node_modules/@wordpress/env": {
-      "version": "5.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-5.16.0.tgz",
-      "integrity": "sha512-zx6UO8PuJBrQ34cfeedK1HlGHLFaj7oWzTo9tTt+noB79Ttqc4+a0lYwDqBLLJhlHU+cWgcyOP2lB6TboXH0xA==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-8.7.0.tgz",
+      "integrity": "sha512-cqjDjFFLZ8691mzsuPaakoNbUJ5d6DNNRMyN6UZefLGKhthlqmyK5DqzXZUzCr9cgF/kdc//v3ZmBy9nywBYSA==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
@@ -7491,15 +7491,15 @@
       }
     },
     "node_modules/cypress": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-11.2.0.tgz",
-      "integrity": "sha512-u61UGwtu7lpsNWLUma/FKNOsrjcI6wleNmda/TyKHe0dOBcVjbCPlp1N6uwFZ0doXev7f/91YDpU9bqDCFeBLA==",
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.2.0.tgz",
+      "integrity": "sha512-AvDQxBydE771GTq0TR4ZUBvv9m9ffXuB/ueEtpDF/6gOcvFR96amgwSJP16Yhqw6VhmwqspT5nAGzoxxB+D89g==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@cypress/request": "^2.88.10",
+        "@cypress/request": "^3.0.0",
         "@cypress/xvfb": "^1.2.4",
-        "@types/node": "^14.14.31",
+        "@types/node": "^18.17.5",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
         "arch": "^2.2.0",
@@ -7511,10 +7511,10 @@
         "check-more-types": "^2.24.0",
         "cli-cursor": "^3.1.0",
         "cli-table3": "~0.6.1",
-        "commander": "^5.1.0",
+        "commander": "^6.2.1",
         "common-tags": "^1.8.0",
         "dayjs": "^1.10.4",
-        "debug": "^4.3.2",
+        "debug": "^4.3.4",
         "enquirer": "^2.3.6",
         "eventemitter2": "6.4.7",
         "execa": "4.1.0",
@@ -7529,12 +7529,13 @@
         "listr2": "^3.8.3",
         "lodash": "^4.17.21",
         "log-symbols": "^4.0.0",
-        "minimist": "^1.2.6",
+        "minimist": "^1.2.8",
         "ospath": "^1.2.2",
         "pretty-bytes": "^5.6.0",
+        "process": "^0.11.10",
         "proxy-from-env": "1.0.0",
         "request-progress": "^3.0.0",
-        "semver": "^7.3.2",
+        "semver": "^7.5.3",
         "supports-color": "^8.1.1",
         "tmp": "~0.2.1",
         "untildify": "^4.0.0",
@@ -7544,13 +7545,13 @@
         "cypress": "bin/cypress"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": "^16.0.0 || ^18.0.0 || >=20.0.0"
       }
     },
     "node_modules/cypress/node_modules/@types/node": {
-      "version": "14.18.54",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.54.tgz",
-      "integrity": "sha512-uq7O52wvo2Lggsx1x21tKZgqkJpvwCseBBPtX/nKQfpVlEsLOb11zZ1CRsWUKvJF0+lzuA9jwvA7Pr2Wt7i3xw==",
+      "version": "18.17.16",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.16.tgz",
+      "integrity": "sha512-e0zgs7qe1XH/X3KEPnldfkD07LH9O1B9T31U8qoO7lqGSjj3/IrBuvqMeJ1aYejXRK3KOphIUDw6pLIplEW17A==",
       "dev": true
     },
     "node_modules/cypress/node_modules/ansi-styles": {
@@ -7613,6 +7614,15 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "node_modules/cypress/node_modules/commander": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/cypress/node_modules/extract-zip": {
       "version": "2.0.1",
@@ -17033,6 +17043,15 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -21215,9 +21234,10 @@
   },
   "dependencies": {
     "@10up/cypress-wp-utils": {
-      "version": "git+ssh://git@github.com/10up/cypress-wp-utils.git#dfd99433b9d63a757810e1e4e285796d63fdc140",
-      "dev": true,
-      "from": "@10up/cypress-wp-utils@github:10up/cypress-wp-utils#build"
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@10up/cypress-wp-utils/-/cypress-wp-utils-0.2.0.tgz",
+      "integrity": "sha512-5gzamtHIFojT+wx0OzSAEeVY6FVrlcVPHVFH23uExkaqQhNsJvrnpdtqtT98wAYkXg56c1qDN7Ju7ZRTaNzP5g==",
+      "dev": true
     },
     "@aashutoshrathi/word-wrap": {
       "version": "1.2.6",
@@ -22524,9 +22544,9 @@
       "requires": {}
     },
     "@cypress/request": {
-      "version": "2.88.12",
-      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.12.tgz",
-      "integrity": "sha512-tOn+0mDZxASFM+cuAP9szGUGPI1HwWVSvdzm7V4cCsPdFTx6qMj29CwaQmRAMIEhORIUBFBsYROYJcveK4uOjA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.1.tgz",
+      "integrity": "sha512-TWivJlJi8ZDx2wGOw1dbLuHJKUYX7bWySw377nlnGOW3hP9/MUKIsEdXT/YngWxVdgNCHRBmFlBipE+5/2ZZlQ==",
       "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
@@ -22542,7 +22562,7 @@
         "json-stringify-safe": "~5.0.1",
         "mime-types": "~2.1.19",
         "performance-now": "^2.1.0",
-        "qs": "~6.10.3",
+        "qs": "6.10.4",
         "safe-buffer": "^5.1.2",
         "tough-cookie": "^4.1.3",
         "tunnel-agent": "^0.6.0",
@@ -24569,9 +24589,9 @@
       }
     },
     "@wordpress/env": {
-      "version": "5.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-5.16.0.tgz",
-      "integrity": "sha512-zx6UO8PuJBrQ34cfeedK1HlGHLFaj7oWzTo9tTt+noB79Ttqc4+a0lYwDqBLLJhlHU+cWgcyOP2lB6TboXH0xA==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-8.7.0.tgz",
+      "integrity": "sha512-cqjDjFFLZ8691mzsuPaakoNbUJ5d6DNNRMyN6UZefLGKhthlqmyK5DqzXZUzCr9cgF/kdc//v3ZmBy9nywBYSA==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
@@ -26703,14 +26723,14 @@
       }
     },
     "cypress": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-11.2.0.tgz",
-      "integrity": "sha512-u61UGwtu7lpsNWLUma/FKNOsrjcI6wleNmda/TyKHe0dOBcVjbCPlp1N6uwFZ0doXev7f/91YDpU9bqDCFeBLA==",
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.2.0.tgz",
+      "integrity": "sha512-AvDQxBydE771GTq0TR4ZUBvv9m9ffXuB/ueEtpDF/6gOcvFR96amgwSJP16Yhqw6VhmwqspT5nAGzoxxB+D89g==",
       "dev": true,
       "requires": {
-        "@cypress/request": "^2.88.10",
+        "@cypress/request": "^3.0.0",
         "@cypress/xvfb": "^1.2.4",
-        "@types/node": "^14.14.31",
+        "@types/node": "^18.17.5",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
         "arch": "^2.2.0",
@@ -26722,10 +26742,10 @@
         "check-more-types": "^2.24.0",
         "cli-cursor": "^3.1.0",
         "cli-table3": "~0.6.1",
-        "commander": "^5.1.0",
+        "commander": "^6.2.1",
         "common-tags": "^1.8.0",
         "dayjs": "^1.10.4",
-        "debug": "^4.3.2",
+        "debug": "^4.3.4",
         "enquirer": "^2.3.6",
         "eventemitter2": "6.4.7",
         "execa": "4.1.0",
@@ -26740,12 +26760,13 @@
         "listr2": "^3.8.3",
         "lodash": "^4.17.21",
         "log-symbols": "^4.0.0",
-        "minimist": "^1.2.6",
+        "minimist": "^1.2.8",
         "ospath": "^1.2.2",
         "pretty-bytes": "^5.6.0",
+        "process": "^0.11.10",
         "proxy-from-env": "1.0.0",
         "request-progress": "^3.0.0",
-        "semver": "^7.3.2",
+        "semver": "^7.5.3",
         "supports-color": "^8.1.1",
         "tmp": "~0.2.1",
         "untildify": "^4.0.0",
@@ -26753,9 +26774,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.18.54",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.54.tgz",
-          "integrity": "sha512-uq7O52wvo2Lggsx1x21tKZgqkJpvwCseBBPtX/nKQfpVlEsLOb11zZ1CRsWUKvJF0+lzuA9jwvA7Pr2Wt7i3xw==",
+          "version": "18.17.16",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.16.tgz",
+          "integrity": "sha512-e0zgs7qe1XH/X3KEPnldfkD07LH9O1B9T31U8qoO7lqGSjj3/IrBuvqMeJ1aYejXRK3KOphIUDw6pLIplEW17A==",
           "dev": true
         },
         "ansi-styles": {
@@ -26801,6 +26822,12 @@
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "commander": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+          "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
           "dev": true
         },
         "extract-zip": {
@@ -33690,6 +33717,12 @@
           "dev": true
         }
       }
+    },
+    "process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "dev": true
     },
     "process-nextick-args": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -34,11 +34,11 @@
     "underscore": "^1.12.1"
   },
   "devDependencies": {
-    "@10up/cypress-wp-utils": "github:10up/cypress-wp-utils#build",
-    "@wordpress/env": "^5.8.0",
+    "@10up/cypress-wp-utils": "^0.2.0",
+    "@wordpress/env": "^8.7.0",
     "@wordpress/eslint-plugin": "^14.11.0",
     "@wordpress/scripts": "^26.9.0",
-    "cypress": "^11.2.0",
+    "cypress": "^13.2.0",
     "eslint": "^8.46.0",
     "eslint-plugin-prettier": "^5.0.0",
     "husky": "^3.1.0",

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Insecure Content Warning ===
 Contributors:      10up, psorensen, adamsilverstein, tlovett, davidrgreen, dkotter, jeffpaul
 Tags:              publishing, publishers, secure content, https, ssl
-Requires at least: 5.7
+Requires at least: 5.8
 Tested up to:      6.3
 Requires PHP:      7.4
 Stable tag:        1.1.0
@@ -19,7 +19,7 @@ Compatible with the "classic" editor as well as the block editor (aka Gutenberg)
 === Technical Notes ===
 
 * Requires PHP 7.4+.
-* Requires WordPress 5.7+.
+* Requires WordPress 5.8+.
 * Requires a secure / SSL (HTTPS) website, front and back end.
 
 === Usage ===

--- a/tests/bin/initialize.sh
+++ b/tests/bin/initialize.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-npm run env run tests-wordpress "chmod -c ugo+w /var/www/html"
-npm run env run tests-cli "wp rewrite structure '/%postname%/' --hard"
+wp-env run tests-wordpress chmod -c ugo+w /var/www/html
+wp-env run tests-cli wp rewrite structure '/%postname%/' --hard

--- a/tests/cypress/cypress.config.js
+++ b/tests/cypress/cypress.config.js
@@ -1,6 +1,7 @@
 const { defineConfig } = require("cypress");
 
 module.exports = defineConfig({
+	chromeWebSecurity: false,
 	fixturesFolder: __dirname + "/fixtures",
 	screenshotsFolder: __dirname + "/screenshots",
 	videosFolder: __dirname + "/videos",

--- a/tests/cypress/e2e/block-editor.test.js
+++ b/tests/cypress/e2e/block-editor.test.js
@@ -6,6 +6,10 @@ describe("Block Editor Tests", () => {
 		cy.deactivatePlugin("classic-editor");
 	});
 
+	beforeEach(() => {
+		cy.login();
+	});
+
 	it("Should display warning, able to use force publish checkbox", () => {
 		const title = "Insecure content " + randomName();
 		cy.createPost({
@@ -35,7 +39,7 @@ describe("Block Editor Tests", () => {
 			beforeSave: () => {
 				cy.insertInsecureBlock();
 				cy.insertBlock("core/paragraph").then((id) => {
-					cy.get(`#${id}`).click().type(randomName());
+					cy.getBlockEditor().find(`#${id}`).click().type(randomName());
 				});
 				cy.insertInsecureBlock();
 
@@ -70,11 +74,11 @@ describe("Block Editor Tests", () => {
 					);
 
 					// Change http to https.
-					cy.get(`#${id} textarea`)
+					cy.getBlockEditor().find(`#${id} textarea`)
 						.invoke("val")
 						.invoke("replaceAll", "http://", "https://")
 						.then((insecure) => {
-							cy.get(`#${id} textarea`).clear().type(insecure);
+							cy.getBlockEditor().find(`#${id} textarea`).clear().type(insecure);
 						});
 				});
 			},

--- a/tests/cypress/plugins/index.js
+++ b/tests/cypress/plugins/index.js
@@ -12,22 +12,24 @@
 // This function is called when a project is opened or re-opened (e.g. due to
 // the project's config changing)
 
-const { readConfig } = require("@wordpress/env/lib/config");
+const { loadConfig } = require('@wordpress/env/lib/config');
+const getCacheDirectory = require('@wordpress/env/lib/config/get-cache-directory');
 
 /**
  * @type {Cypress.PluginConfig}
  */
 // eslint-disable-next-line no-unused-vars
 module.exports = async (on, config) => {
-  wpEnvConfig = await readConfig("wp-env");
+	const cacheDirectory = await getCacheDirectory();
+	const wpEnvConfig = await loadConfig(cacheDirectory);
 
-  if (wpEnvConfig) {
-    const port = wpEnvConfig.env.tests.port || null;
+	if (wpEnvConfig) {
+		const port = wpEnvConfig.env.tests.port || null;
 
-    if (port) {
-      config.baseUrl = wpEnvConfig.env.tests.config.WP_SITEURL;
-    }
-  }
+		if (port) {
+			config.baseUrl = wpEnvConfig.env.tests.config.WP_SITEURL;
+		}
+	}
 
-  return config;
+	return config;
 };

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -29,7 +29,7 @@ Cypress.Commands.add("clickPublish", () => {
 });
 
 Cypress.Commands.add("editBlockAsHTML", (id) => {
-	cy.get(`#${id}`).focus();
+	cy.getBlockEditor().find(`#${id}`).focus();
 
 	// Open HTML editor.
 	cy.get(
@@ -44,21 +44,21 @@ Cypress.Commands.add("editBlockAsHTML", (id) => {
 
 Cypress.Commands.add("insertInsecureBlock", (after) => {
 	cy.insertBlock("core/image").then((id) => {
-		cy.get(
+		cy.getBlockEditor().find(
 			`#${id} .components-form-file-upload input[type=file]`
 		).selectFile("tests/cypress/fixtures/example.jpg", { force: true });
 
 		// Wait for spinner to go away.
-		cy.get(`#${id} .components-spinner`).should("not.exist");
+		cy.getBlockEditor().find(`#${id} .components-spinner`).should("not.exist");
 
 		cy.editBlockAsHTML(id);
 
 		// Change https to http.
-		cy.get(`#${id} textarea`)
+		cy.getBlockEditor().find(`#${id} textarea`)
 			.invoke("val")
 			.invoke("replaceAll", "https://", "http://")
 			.then((insecure) => {
-				cy.get(`#${id} textarea`).clear().type(insecure);
+				cy.getBlockEditor().find(`#${id} textarea`).clear().type(insecure);
 			});
 
 		if (after) {
@@ -69,7 +69,7 @@ Cypress.Commands.add("insertInsecureBlock", (after) => {
 
 Cypress.Commands.add("insertInsecureHTMLBlock", (after) => {
 	cy.insertBlock("core/html").then((id) => {
-		cy.get(`#${id} textarea`)
+		cy.getBlockEditor().find(`#${id} textarea`)
 			.type('<img src="http://google.com/dummy1.jpg" />', { force: true })
 		if (after) {
 			after(id);

--- a/tests/cypress/support/index.js
+++ b/tests/cypress/support/index.js
@@ -17,11 +17,3 @@ import "@10up/cypress-wp-utils";
 
 // Import commands.js using ES2015 syntax:
 import "./commands";
-
-// Alternatively you can use CommonJS syntax:
-// require('./commands')
-beforeEach(() => {
-  Cypress.Cookies.defaults({
-    preserve: /^wordpress.*?/,
-  });
-});


### PR DESCRIPTION
### Description of the Change
This PR fixes the E2E failure that occurred due to Block Editor now loading in an iframe by default in WP 6.3

PR upgrades the Cypress, Cypress utils lib, and @wordpress/env. Updates needed files as part of the upgrade.
- Bump `Cypress` version from 11.2.0 to 13.2.0
- Bump `@10up/cypress-wp-utils` version to 0.2.0
- Bump `@wordpress/env` version from 5.8.0 to 8.7.0

Also, PR upgrades minimum supported WP version from 5.7 to 5.8. (While investigating e2e failure on minimum, I found that code refactored in https://github.com/10up/insecure-content-warning/pull/56 drops supports of WP 5.7)

Closes #115
Closes #141

### How to test the Change
Make sure PR `PASS` E2E tests check OR verify E2E tests locally.

### Changelog Entry
> Fixed - Ensure all E2E tests pass when running on WordPress 6.3
> Changed - Bump minimum WordPress version from `5.7` to `5.8`
> Changed - Bump `Cypress` version from 11.2.0 to 13.2.0
> Changed - Bump `@10up/cypress-wp-utils` version to 0.2.0
> Changed - Bump `@wordpress/env` version from 5.8.0 to 8.7.0


### Credits
Props @iamdharmesh @Sidsector9 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
