### PR TITLE
Bump WordPress "tested up to" version 6.6 

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -44,7 +44,7 @@ jobs:
       matrix:
         core:
           - {name: 'WP latest', version: 'latest'}
-          - {name: 'WP minimum', version: 'WordPress/WordPress#6.3'}
+          - {name: 'WP minimum', version: 'WordPress/WordPress#6.4'}
           - {name: 'WP trunk', version: 'WordPress/WordPress#master'}
     steps:
     - name: Checkout

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Compatible with both the block and classic editors.
 ## Requirements
 
 * PHP 7.4+.
-* WordPress 5.8+.
+* WordPress 6.4+.
 * A secure / SSL (HTTPS) website, front and back end.
 
 ## Installation

--- a/insecure-content-warning.php
+++ b/insecure-content-warning.php
@@ -4,7 +4,7 @@
  * Plugin URI:        https://wordpress.org/plugins/insecure-content-warning/
  * Description:       Prevent editors from adding insecure content in the editor.
  * Version:           1.2.0
- * Requires at least: 6.3
+ * Requires at least: 6.4
  * Requires PHP:      7.4
  * Author:            10up
  * Author URI:        https://10up.com/

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@10up/cypress-wp-utils": "^0.3.0",
-    "@wordpress/env": "^10.2.0",
+    "@wordpress/env": "^9.2.0",
     "@wordpress/scripts": "^27.1.0",
     "cypress": "^13.2.0",
     "husky": "^3.1.0"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@10up/cypress-wp-utils": "^0.3.0",
-    "@wordpress/env": "^9.2.0",
+    "@wordpress/env": "^10.2.0",
     "@wordpress/scripts": "^27.1.0",
     "cypress": "^13.2.0",
     "husky": "^3.1.0"

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Insecure Content Warning ===
 Contributors:      10up, psorensen, adamsilverstein, tlovett, davidrgreen, dkotter, jeffpaul
 Tags:              publishing, publishers, secure content, https, ssl
-Tested up to:      6.5
+Tested up to:      6.6
 Stable tag:        1.2.0
 License:           GPLv2 or later
 License URI:       http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
### Description of the Change
This PR bumps the WP tested up to version 6.6, and bumps the WP min to 6.4. 

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes https://github.com/10up/insecure-content-warning/issues/174

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Bump WordPress "tested up to" version 6.6.
> Changed - Bump WordPress minimum from 6.3 to 6.4.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @ankitguptaindia 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
