### PR TITLE
Update WordPress version requirement to 6.8

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,6 +19,7 @@
 			"@wordpress/dom-ready",
 			"@wordpress/dom",
 			"@wordpress/edit-post",
+			"@wordpress/editor",
 			"@wordpress/element",
 			"@wordpress/hooks",
 			"@wordpress/i18n",

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         core:
           - {name: 'WP latest', version: 'latest'}
-          - {name: 'WP minimum', version: 'WordPress/WordPress#6.6'}
+          - {name: 'WP minimum', version: 'WordPress/WordPress#6.8'}
           - {name: 'WP trunk', version: 'WordPress/WordPress#master'}
 
     steps:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Compatible with both the block and classic editors.
 ## Requirements
 
 * PHP 7.4+.
-* WordPress 6.6+.
+* WordPress 6.8+.
 * A secure / SSL (HTTPS) website, front and back end.
 
 ## Installation

--- a/insecure-content-warning.php
+++ b/insecure-content-warning.php
@@ -4,7 +4,7 @@
  * Plugin URI:        https://wordpress.org/plugins/insecure-content-warning/
  * Description:       Prevent editors from adding insecure content in the editor.
  * Version:           1.2.2
- * Requires at least: 6.6
+ * Requires at least: 6.8
  * Requires PHP:      7.4
  * Author:            10up
  * Author URI:        https://10up.com/

--- a/insecure-content-warning.php
+++ b/insecure-content-warning.php
@@ -4,8 +4,6 @@
  * Plugin URI:        https://wordpress.org/plugins/insecure-content-warning/
  * Description:       Prevent editors from adding insecure content in the editor.
  * Version:           1.2.2
- * Requires at least: 6.8
- * Requires PHP:      7.4
  * Author:            10up
  * Author URI:        https://10up.com/
  * License:           GPL v2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,9 @@
 === Insecure Content Warning ===
 Contributors:      10up, psorensen, adamsilverstein, tlovett, davidrgreen, dkotter, jeffpaul
 Tags:              publishing, publishers, secure content, https, ssl
+Requires at least: 6.8
 Tested up to:      7.0
+Requires PHP:      7.4
 Stable tag:        1.2.2
 License:           GPLv2 or later
 License URI:       http://www.gnu.org/licenses/gpl-2.0.html

--- a/src/js/utils/gutenberg-status.js
+++ b/src/js/utils/gutenberg-status.js
@@ -3,12 +3,7 @@ import { CheckboxControl } from '@wordpress/components';
 import { dispatch } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 import { registerPlugin } from '@wordpress/plugins';
-
-// Once WordPress 6.6 becomes our minimum, change this back to `import { PluginPostStatusInfo } from '@wordpress/editor';`.
-const PluginPostStatusInfo =
-	wp.editor?.PluginPostStatusInfo ??
-	wp.editPost?.PluginPostStatusInfo ??
-	wp.editSite?.PluginPostStatusInfo;
+import { PluginPostStatusInfo } from '@wordpress/editor';
 
 export const registerInsecureContentPlugin = ( insecureElementURLs ) => {
 	const renderInsecureContentWarnings = () => {


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Bumps the WP minimum to 6.8 now that the tested-up-to is 7.0 (in alignment with an L-2 support policy).

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #205.

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Changed - Bump WordPress minimum supported version to 6.8.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @jeffpaul.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
