### PR TITLE
WP Compatibility Check Against WP Core 7.1

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -20,6 +20,7 @@ jobs:
     if: always()
 
     strategy:
+      fail-fast: false
       matrix:
         core:
           - {name: 'WP latest', version: 'latest'}

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         core:
           - {name: 'WP latest', version: 'latest'}
-          - {name: 'WP minimum', version: 'WordPress/WordPress#6.8'}
+          - {name: 'WP minimum', version: 'WordPress/WordPress#6.9'}
           - {name: 'WP trunk', version: 'WordPress/WordPress#master'}
 
     steps:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Compatible with both the block and classic editors.
 ## Requirements
 
 * PHP 7.4+.
-* WordPress 6.8+.
+* WordPress 6.9+.
 * A secure / SSL (HTTPS) website, front and back end.
 
 ## Installation

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors:      10up, psorensen, adamsilverstein, tlovett, davidrgreen, dkotter, jeffpaul
 Tags:              publishing, publishers, secure content, https, ssl
 Requires at least: 6.8
-Tested up to:      7.0
+Tested up to:      7.1
 Requires PHP:      7.4
 Stable tag:        1.2.2
 License:           GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Insecure Content Warning ===
 Contributors:      10up, psorensen, adamsilverstein, tlovett, davidrgreen, dkotter, jeffpaul
 Tags:              publishing, publishers, secure content, https, ssl
-Requires at least: 6.8
+Requires at least: 6.9
 Tested up to:      7.1
 Requires PHP:      7.4
 Stable tag:        1.2.2


### PR DESCRIPTION
### Description of the Change
Tested compatibility against WP Core 7.1. The plugin functions as expected with 7.1

Closes #223

### How to test the Change

1. Update WP Core version to 7.1
2. Create a post and add image served with http
3. Try to publish
4. Publishing should be not permitted and a warning of insecure content appears.
5. Bypassing options, fix the image, etc should work as expected.

### Changelog Entry
> Changed - Bumped up Tested up to from 7.0 to 7.1
> Changed - Minimum supported version of WordPress is now 6.9

### Credits
Props @oscarssanchezz 

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
